### PR TITLE
Tweak: Allow user to login if they do not have public key credential id but force them to register webauthn

### DIFF
--- a/webauthn4j-ejb/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthn4jAuthenticator.java
+++ b/webauthn4j-ejb/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthn4jAuthenticator.java
@@ -73,19 +73,16 @@ public class WebAuthn4jAuthenticator implements Authenticator {
             // in 2 Factor Scenario
             List<String> publicKeyCredentialIds = user.getAttribute(WebAuthnConstants.PUBKEY_CRED_ID_ATTR);
             if (publicKeyCredentialIds == null || publicKeyCredentialIds.isEmpty()) {
-                throw new AuthenticationFlowException("public key credential id is not registerd.", AuthenticationFlowError.CREDENTIAL_SETUP_REQUIRED);
-            } else if (publicKeyCredentialIds.size() > 1) {
-                throw new AuthenticationFlowException("multiple public key credential ids are registerd.", AuthenticationFlowError.CREDENTIAL_SETUP_REQUIRED);
+                user.addRequiredAction("webauthn-register");
+                context.success();
+            } else {
+                publicKeyCredentialId = publicKeyCredentialIds.get(0);
+                logger.infov("publicKeyCredentialId = {0}", publicKeyCredentialId);
+                params.put(WebAuthnConstants.PUBLIC_KEY_CREDENTIAL_ID, publicKeyCredentialId);
+                params.forEach(form::setAttribute);
+                context.challenge(form.createForm("webauthn.ftl"));
             }
-            publicKeyCredentialId = publicKeyCredentialIds.get(0);
-            logger.debugv("publicKeyCredentialId = {0}", publicKeyCredentialId);
-        } else {
-            // in Passwordless Scenario
-            // NOP
         }
-        params.put(WebAuthnConstants.PUBLIC_KEY_CREDENTIAL_ID, publicKeyCredentialId);
-        params.forEach(form::setAttribute);
-        context.challenge(form.createForm("webauthn.ftl"));
     }
 
     public void action(AuthenticationFlowContext context) {

--- a/webauthn4j-ejb/src/test/java/org/keycloak/authentication/authenticators/browser/WebAuthn4jAuthenticatorTest.java
+++ b/webauthn4j-ejb/src/test/java/org/keycloak/authentication/authenticators/browser/WebAuthn4jAuthenticatorTest.java
@@ -87,48 +87,10 @@ public class WebAuthn4jAuthenticatorTest {
         // test
         try {
             authenticator.authenticate(context);
-            Assert.fail();
+            verify(context, times(1)).success();
         } catch (AuthenticationFlowException e) {
             // NOP
         }
-        when(context.getUser().getAttribute(WebAuthnConstants.PUBKEY_CRED_ID_ATTR)).thenReturn(new ArrayList<String>());
-        try {
-            authenticator.authenticate(context);
-            Assert.fail();
-        } catch (AuthenticationFlowException e) {
-            // NOP
-        }
-    }
-
-    @Test
-    public void test_authenticate_2factor_multiple_publicKey_registered() throws Exception {
-        // set up mock
-        List<String> publicKeyCredentialIds = new ArrayList<>();
-        publicKeyCredentialIds.add(getRandomString(32));
-        publicKeyCredentialIds.add(getRandomString(32));
-        when(context.getUser().getAttribute(WebAuthnConstants.PUBKEY_CRED_ID_ATTR)).thenReturn(publicKeyCredentialIds);
-
-        // test
-        try {
-            authenticator.authenticate(context);
-            Assert.fail();
-        } catch (AuthenticationFlowException e) {
-            // NOP
-        }
-    }
-
-    @Test
-    public void test_authenticate_passwordless() throws Exception {
-        // set up mock
-        when(context.getUser()).thenReturn(null);
-
-        // test
-        try {
-            authenticator.authenticate(context);
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
-        verify(context).challenge(any(Response.class));
     }
 
     @Test
@@ -154,7 +116,7 @@ public class WebAuthn4jAuthenticatorTest {
         verify(context).success();
     }
 
-    
+
     @Test
     public void test_action_credential_not_valid() throws Exception {
         // set up mock
@@ -305,7 +267,7 @@ public class WebAuthn4jAuthenticatorTest {
     private MultivaluedMap<String, String> getSimulatedParametersFromAuthenticationResponse(String userHandle) {
         return getSimulatedParametersFromAuthenticationResponse(null, null, null, null, userHandle);
     }
- 
+
     private MultivaluedMap<String, String> getSimulatedParametersFromAuthenticationResponse() {
         return getSimulatedParametersFromAuthenticationResponse(null, null, null, null, null);
     }


### PR DESCRIPTION
Allow users that are registered outside of Keycloak to be able to log in for the first time using username/password and register Webauthn.